### PR TITLE
Stop buffering ressource content and stream directly back to client

### DIFF
--- a/include_private/http_private.h
+++ b/include_private/http_private.h
@@ -1,6 +1,7 @@
 #ifndef _HTTP_PRIVATE
 #define _HTTP_PRIVATE
 
+#include <sys/stat.h>
 #include "http.h"
 
 #define NUM_RECOGNIZED_EXT_MAPPINGS 5
@@ -19,11 +20,11 @@ struct _http_req{
 struct _http_resp {
     char status[MAX_RESP_STATUS_LEN];
     char headers[MAX_RESP_HEADERS_LEN];
-    char body[MAX_RESP_BODY_LEN];
+    int  ressource_fd;
     http_response_type response_type;
-    
+
     // Internal use only
-    uint32_t         _content_len;
+    off_t            _content_len;
     char             _content_type[MAX_RES_TYPE_LEN];
     http_return_code _return_code;
 };

--- a/include_public/http.h
+++ b/include_public/http.h
@@ -21,8 +21,7 @@
 #define MAX_RES_TYPE_LEN      30
 
 #define MAX_RESP_STATUS_LEN  60
-#define MAX_RESP_HEADERS_LEN 200
-#define MAX_RESP_BODY_LEN    500000
+#define MAX_RESP_HEADERS_LEN 500
 
 #define ENUM_GEN(ENUM) ENUM,
 #define STRING_GEN(STRING) #STRING,
@@ -146,24 +145,23 @@ int get_http_response_status(http_resp response, char *status, size_t max_status
 
 
 /**
- * @brief Get the http response body
+ * @brief Get the http response content size (bytes)
  * 
- * @param response the response from which to retrieve the body
- * @param body buffer to store the body
- * @param max_body_len max length of body to copy into provided buffer
- * @return int 0 if the body is successfully retrieved, otherwise -1
+ * @param response the response from which to retrieve the content size
+ * @param content_size reference to store the http response content size
+ * @return int 0 if the content size is successfully retrieved, otherwise -1
  */
-int get_http_response_body(http_resp response, char *body, size_t max_body_len);
+int get_http_response_content_size(http_resp response, off_t *content_size);
 
 
 /**
- * @brief Get the http response body size (bytes)
+ * @brief Get the http response resssource fd.
  * 
- * @param response the response from which to retrieve the body size
- * @param body_size reference to store the http response body size
- * @return int 0 if the body size is successfully retrieved, otherwise -1
+ * @param response the response from which to retrieve the ressource fd
+ * @param ressource_fd reference to store the ressource fd
+ * @return int 0 if the fd was retrieved successfully, otherwise -1
  */
-int get_http_response_body_size(http_resp response, size_t *body_size);
+int get_http_response_ressource_fd(http_resp response, int *ressource_fd);
 
 
 /**

--- a/include_public/rio.h
+++ b/include_public/rio.h
@@ -64,13 +64,24 @@ ssize_t readline_b(rio_t rp, void *userbuf, size_t maxlen);
 
 
 /**
- * @brief Attempt to write num_bytes from userbuf to fd.
+ * @brief Attempt to write num_bytes from a userbuf to fd.
  * 
  * @param fd File descriptor to write to.
  * @param userbuf Pointer to buffer containing contents to write.
  * @param num_bytes Number of bytes to write from userbuf.
  * @return 0 if everything was written, otherwise -1.
  */
-ssize_t writen(int fd, void *userbuf, size_t num_bytes);
+ssize_t writen_b(int fd, void *userbuf, size_t num_bytes);
+
+
+/**
+ * @brief Attempt to write num_bytes from in_fd to out_fd.
+ * 
+ * @param out_fd File descriptor to write to.
+ * @param in_fd File descriptor to read from.
+ * @param num_bytes Number of bytes to write between fds.
+ * @return 0 if everything was written, otherwise -1.
+ */
+ssize_t writen(int out_fd, int in_fd, size_t num_bytes);
 
 #endif


### PR DESCRIPTION
- Prior to this commit, the resource was being temporarily held in memory which limits the flexibility of the server. Instead of buffering the data, stream it directly back to the client. 